### PR TITLE
add support for the Node 4.x

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -29,7 +29,7 @@ function encode(source) {
   while (padding--) {
     result[--cursor] = 61;
   }
-  return String.fromCharCode(...result);
+  return String.fromCharCode.apply(null, result);
 }
 
 function decode(source) {


### PR DESCRIPTION
Node v4.x hasn't supported spread operator.
