### PR TITLE
Goodbye ES6 syntax

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -52,4 +52,7 @@ function decode(source) {
   return result;
 }
 
-module.exports = { encode, decode };
+module.exports = {
+  encode: encode,
+  decode: decode
+};


### PR DESCRIPTION
Shorthand properties doesn't work in the old JS engines.
