### PR TITLE
Adding support for a basic web browsers fix #2

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -1,58 +1,64 @@
 'use strict';
 
-var ENCODE_BASE64_TABLE = [];
-var DECODE_BASE64_TABLE = [];
-(function(characters) {
-  var index, code;
-  for (index = characters.length - 1; index >= 0; --index) {
-    code = characters.charCodeAt(index);
-    ENCODE_BASE64_TABLE[index] = code & 0xff;
-    DECODE_BASE64_TABLE[code] = index;
-  }
-  DECODE_BASE64_TABLE['='.charCodeAt(0)] = 0;
-})('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/');
+var base64 = (function() {
+  var ENCODE_BASE64_TABLE = [];
+  var DECODE_BASE64_TABLE = [];
+  (function(characters) {
+    var index, code;
+    for (index = characters.length - 1; index >= 0; --index) {
+      code = characters.charCodeAt(index);
+      ENCODE_BASE64_TABLE[index] = code & 0xff;
+      DECODE_BASE64_TABLE[code] = index;
+    }
+    DECODE_BASE64_TABLE['='.charCodeAt(0)] = 0;
+  })('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/');
 
-function encode(source) {
-  var sourceLength = source.length;
-  var padding = 3 - (sourceLength % 3 || 3);
-  var length = Math.floor((sourceLength + 2) / 3) * 4;
-  var result = new Uint8Array(length);
-  var cursor = 0;
-  var i, bits;
-  for (i = 0; i < sourceLength; cursor += 4, i += 3) {
-    bits = (source[i] & 0xff) << 16
-      | (source[i + 1] & 0xff) << 8
-      | (source[i + 2] & 0xff);
-    result[cursor] = ENCODE_BASE64_TABLE[bits >> 18 & 0x3f];
-    result[cursor + 1] = ENCODE_BASE64_TABLE[bits >> 12 & 0x3f];
-    result[cursor + 2] = ENCODE_BASE64_TABLE[bits >> 6 & 0x3f];
-    result[cursor + 3] = ENCODE_BASE64_TABLE[bits & 0x3f];
+  function encode(source) {
+    var sourceLength = source.length;
+    var padding = 3 - (sourceLength % 3 || 3);
+    var length = Math.floor((sourceLength + 2) / 3) * 4;
+    var result = new Uint8Array(length);
+    var cursor = 0;
+    var i, bits;
+    for (i = 0; i < sourceLength; cursor += 4, i += 3) {
+      bits = (source[i] & 0xff) << 16
+        | (source[i + 1] & 0xff) << 8
+        | (source[i + 2] & 0xff);
+      result[cursor] = ENCODE_BASE64_TABLE[bits >> 18 & 0x3f];
+      result[cursor + 1] = ENCODE_BASE64_TABLE[bits >> 12 & 0x3f];
+      result[cursor + 2] = ENCODE_BASE64_TABLE[bits >> 6 & 0x3f];
+      result[cursor + 3] = ENCODE_BASE64_TABLE[bits & 0x3f];
+    }
+    while (padding--) {
+      result[--cursor] = 61;
+    }
+    return String.fromCharCode.apply(null, result);
   }
-  while (padding--) {
-    result[--cursor] = 61;
+
+  function decode(source) {
+    var sourceLength = source.length;
+    var padding = source.slice(sourceLength - 2).split('=').length - 1;
+    var length = Math.floor((sourceLength + 3) / 4) * 3 - padding;
+    var result = new Uint8Array(length);
+    var cursor, i, bits;
+    for (cursor = 0, i = 0; i < sourceLength; cursor += 3, i += 4) {
+      bits = DECODE_BASE64_TABLE[source[i].charCodeAt(0)] << 18
+        | DECODE_BASE64_TABLE[source[i + 1].charCodeAt(0)] << 12
+        | DECODE_BASE64_TABLE[source[i + 2].charCodeAt(0)] << 6
+        | DECODE_BASE64_TABLE[source[i + 3].charCodeAt(0)];
+      result[cursor] = (bits >> 16) & 0xff;
+      result[cursor + 1] = (bits >> 8) & 0xff;
+      result[cursor + 2] = bits & 0xff;
+    }
+    return result;
   }
-  return String.fromCharCode.apply(null, result);
+
+  return {
+    encode: encode,
+    decode: decode
+  };
+})();
+
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  module.exports = base64;
 }
-
-function decode(source) {
-  var sourceLength = source.length;
-  var padding = source.slice(sourceLength - 2).split('=').length - 1;
-  var length = Math.floor((sourceLength + 3) / 4) * 3 - padding;
-  var result = new Uint8Array(length);
-  var cursor, i, bits;
-  for (cursor = 0, i = 0; i < sourceLength; cursor += 3, i += 4) {
-    bits = DECODE_BASE64_TABLE[source[i].charCodeAt(0)] << 18
-      | DECODE_BASE64_TABLE[source[i + 1].charCodeAt(0)] << 12
-      | DECODE_BASE64_TABLE[source[i + 2].charCodeAt(0)] << 6
-      | DECODE_BASE64_TABLE[source[i + 3].charCodeAt(0)];
-    result[cursor] = (bits >> 16) & 0xff;
-    result[cursor + 1] = (bits >> 8) & 0xff;
-    result[cursor + 2] = bits & 0xff;
-  }
-  return result;
-}
-
-module.exports = {
-  encode: encode,
-  decode: decode
-};

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>binary-base64 example</title>
+<p><output id="base64-encode-result"></output></p>
+<script src="../base64.js"></script>
+<script>
+(function() {
+  var result = document.getElementById('base64-encode-result');
+  var request = new XMLHttpRequest();
+  request.addEventListener('load', function() {
+    var buffer = new Uint8Array(this.response);
+    result.value = base64.encode(buffer);
+  });
+  request.responseType = 'arraybuffer';
+  request.open('get', 'https://www.gravatar.com/avatar/b9025074d487cd0328f1dc816e5ac50a.jpg');
+  request.send(null);
+})();
+</script>


### PR DESCRIPTION
fix #2

``` html
<p><output id="base64-encode-result"></output></p>
<script src="./base64.js"></script>
<script>
(function() {
  var result = document.getElementById('base64-encode-result');
  var request = new XMLHttpRequest();
  request.addEventListener('load', function() {
    var buffer = new Uint8Array(this.response);
    result.value = base64.encode(buffer);
  });
  request.responseType = 'arraybuffer';
  request.open('get', 'https://www.gravatar.com/avatar/b9025074d487cd0328f1dc816e5ac50a.jpg');
  request.send(null);
})();
</script>
```
